### PR TITLE
[참] - 로그인 페이지 : 로그인 후 유저 정보 저장 로직 구현

### DIFF
--- a/src/components/login_page/Form.tsx
+++ b/src/components/login_page/Form.tsx
@@ -1,11 +1,14 @@
+import { useLoggedInUserStore } from '@/shared/store/LoggedInUser';
 import { supabase } from '@/shared/supabase/supabase';
 import { useRouter } from 'next/navigation';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 export function Form() {
   const router = useRouter();
+  const { setUserData } = useLoggedInUserStore();
   const [loginInfo, setLoginInfo] = useState({ email: '', password: '' });
-  //TODO: 에러 유형 추가
+
+  const INVALID_LOGIN_CREDENTIAL = 'Invalid login credentials';
 
   const handleLoginInfo = {
     handleEmail: (event: ChangeEvent<HTMLInputElement>) => {
@@ -31,14 +34,16 @@ export function Form() {
       });
       if (error) {
         switch (error.message) {
-          //TODO : error handling logic 추가
+          case INVALID_LOGIN_CREDENTIAL:
+            alert('이메일 또는 비밀번호가 올바르지 않습니다.');
+            break;
           default:
             alert(`에러가 발생하였습니다.\n${error.message}`);
         }
         return;
       }
       if (data) {
-        //TODO : 유저 정보를 넘겨주는 로직(zustand 상태관리 필요)
+        setUserData({ email: loginInfo.email, user_id: data.user.id, nickname: data.user.user_metadata.display_name });
         router.push('/home_page');
       }
     } catch (error) {

--- a/src/components/signup_page/Form.tsx
+++ b/src/components/signup_page/Form.tsx
@@ -1,0 +1,130 @@
+import { supabase } from '@/shared/supabase/supabase';
+import { useRouter } from 'next/navigation';
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+export function Form() {
+  const router = useRouter();
+  const [userInfo, setUserInfo] = useState({ nickname: '', email: '', password: '', verify_password: '' });
+  //에러 유형 - 따로 빼는 것이 좋아보임
+  const INVALID_PASSWORD = 'Password should be at least 6 characters.';
+  const INVALID_EMAIL = 'Unable to validate email address: invalid format';
+  const EXISTING_EMAIL = 'User already registered';
+  const INVALID_INPUT = 'Invalid login credentials';
+
+  const handleUserInfo = {
+    handleNickname: (event: ChangeEvent<HTMLInputElement>) => {
+      setUserInfo((prev) => ({
+        ...prev,
+        nickname: event.target.value,
+      }));
+    },
+    handleEmail: (event: ChangeEvent<HTMLInputElement>) => {
+      setUserInfo((prev) => ({
+        ...prev,
+        email: event.target.value,
+      }));
+    },
+    handlePassword: (event: ChangeEvent<HTMLInputElement>) => {
+      setUserInfo((prev) => ({
+        ...prev,
+        password: event.target.value,
+      }));
+    },
+    handleVerifyPassword: (event: ChangeEvent<HTMLInputElement>) => {
+      setUserInfo((prev) => ({
+        ...prev,
+        verify_password: event.target.value,
+      }));
+    },
+  };
+
+  const handleSignup = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isVerifiedPassword({ password: userInfo.password, verify_password: userInfo.verify_password })) {
+        const { data, error } = await supabase.auth.signUp({
+          email: userInfo.email,
+          password: userInfo.password,
+          options: {
+            data: {
+              display_name: userInfo.nickname,
+            },
+          },
+        });
+        if (error) {
+          switch (error.message) {
+            case INVALID_EMAIL:
+              alert('유효하지 않은 이메일 형식입니다.');
+              break;
+            case INVALID_PASSWORD:
+              alert('비밀번호는 6자 이상으로 설정해주세요.');
+              break;
+            case EXISTING_EMAIL:
+              alert('이미 존재하는 이메일입니다.');
+              break;
+            case INVALID_INPUT:
+              alert('유효하지 않은 입력값입니다.');
+              break;
+            default:
+              alert(`에러가 발생하였습니다.\n${error.message}`);
+          }
+        } else {
+          alert('반갑습니다! 오늘도 쾌변!');
+          router.push('/login_page');
+        }
+      } else alert('비밀번호가 일치하지 않습니다.');
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const isVerifiedPassword = ({ password, verify_password }: { password: string; verify_password: string }) => {
+    return password === verify_password;
+  };
+
+  return (
+    <form className="flex flex-col pt-10" onSubmit={handleSignup}>
+      <label htmlFor="nickname">닉네임</label>
+      <input
+        id="nickname"
+        type="text"
+        placeholder="NICKNAME (최대 10자)"
+        maxLength={10}
+        value={userInfo.nickname}
+        onChange={handleUserInfo.handleNickname}
+        autoComplete="off"
+        required
+      />
+      <br />
+      <label htmlFor="email">이메일</label>
+      <input
+        id="email"
+        type="text"
+        placeholder="EMAIL"
+        value={userInfo.email}
+        onChange={handleUserInfo.handleEmail}
+        autoComplete="off"
+      />
+      <br />
+      <label htmlFor="password">비밀번호</label>
+      <input
+        id="password"
+        type="password"
+        placeholder="PASSWORD (6+)"
+        value={userInfo.password}
+        onChange={handleUserInfo.handlePassword}
+      />
+      <br />
+      <label htmlFor="verify_password">비밀번호 확인</label>
+      <input
+        id="verify_password"
+        type="password"
+        placeholder="VERIFY_PASSWORD"
+        value={userInfo.verify_password}
+        onChange={handleUserInfo.handleVerifyPassword}
+      />
+      <br />
+      <button className="bg-gray-400">회원가입하기</button>
+    </form>
+  );
+}

--- a/src/shared/store/LoggedInUser.ts
+++ b/src/shared/store/LoggedInUser.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+type store = {
+  userData: { email: string; password: string };
+  setUserData: ({ email, password }: { email: string; password: string }) => boolean;
+};
+
+export const useLoggedInUserStore = create((set) => ({
+  userData: { email: '', password: '' },
+  setUserData: ({ email, password }: { email: string; password: string }) => {
+    set({ userData: { email, password } });
+  },
+}));

--- a/src/shared/store/LoggedInUser.ts
+++ b/src/shared/store/LoggedInUser.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand';
 
-type store = {
-  userData: { email: string; password: string };
-  setUserData: ({ email, password }: { email: string; password: string }) => boolean;
+type Store = {
+  userData: { email: string; user_id: string; nickname: string };
+  setUserData: ({ email, user_id, nickname }: { email: string; user_id: string; nickname: string }) => void;
 };
 
-export const useLoggedInUserStore = create((set) => ({
-  userData: { email: '', password: '' },
-  setUserData: ({ email, password }: { email: string; password: string }) => {
-    set({ userData: { email, password } });
+export const useLoggedInUserStore = create<Store>((set) => ({
+  userData: { email: '', user_id: '', nickname: 'poopy' },
+  setUserData: ({ email, user_id, nickname }) => {
+    set({ userData: { email, user_id, nickname } });
   },
 }));


### PR DESCRIPTION
## 📌 관련 이슈

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
<img width="649" alt="스크린샷 2024-03-21 오후 4 25 31" src="https://github.com/wheres-my-toilet/wheres-my-toilet/assets/69431340/bd2befe5-e184-489e-8d52-ea304a9c656a">

- [x] 빈 값으로 제출했을 때 에러 핸들링 로직을 추가해야합니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
1. shared/store 아래에 LoggedInUser.ts 파일을 생성하였습니다. 
로그인 한 유저의 email, user_id, nickname 정보를 다룹니다.
로그인에 성공했을 시 해당 값이 store에 저장됩니다.
2. 로그인 시 비밀번호 또는 아이디가 일치하지 않을 때의 에러 핸들링 로직을 추가했습니다.
```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
## 📸 스크린샷(선택)
<img width="649" alt="스크린샷 2024-03-21 오후 4 32 02" src="https://github.com/wheres-my-toilet/wheres-my-toilet/assets/69431340/0096a01f-d8ba-4204-a927-8ecedec75375">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
zustand 공부하며 참고한 자료입니다. (<a href="https://velog.io/@yeonsubaek/React-Zustand%EB%A1%9C-%ED%8E%B8%EB%A6%AC%ED%95%98%EA%B2%8C-%EC%83%81%ED%83%9C%EA%B4%80%EB%A6%AC%ED%95%98%EA%B8%B0">여기</a>)