### PR TITLE
[지수] - 유저 id 임시값에서 로그인한 유저 정보로 조회하도록 작업 및 미 로그인 시 로그인 페이지로 이동 작업

### DIFF
--- a/src/components/bookmark_page/BookmarkList.tsx
+++ b/src/components/bookmark_page/BookmarkList.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React, { useEffect } from 'react';
 import { PiToiletPaper } from 'react-icons/pi';
+import { AiOutlineLoading } from 'react-icons/ai';
 
 const BookmarkList = () => {
   const { userData } = useLoggedInUserStore();
@@ -18,7 +19,7 @@ const BookmarkList = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
 
-  const { data } = useQuery<Bookmark[]>({
+  const { data, isLoading } = useQuery<Bookmark[]>({
     queryFn: () => getData(USER_ID),
     queryKey: [QUERY_KEY_BOOKMARK, userData?.user_uid],
     enabled: !!USER_ID,
@@ -47,9 +48,9 @@ const BookmarkList = () => {
   };
 
   useEffect(() => {
-    const { user } = JSON.parse(localStorage.getItem('sb-pqqdwvdmqkezxbipblds-auth-token') as string);
+    const userData = JSON.parse(localStorage.getItem('sb-pqqdwvdmqkezxbipblds-auth-token') as string);
 
-    if (!user.id) {
+    if (!userData || !userData.user.id) {
       router.replace('/login_page');
     }
   }, []);

--- a/src/components/home_page/HomeCategory.tsx
+++ b/src/components/home_page/HomeCategory.tsx
@@ -5,7 +5,7 @@ function HomeCategory() {
     <nav>
       <ul className="border-2  w-100 ml-10 mt-10 p-10 sticky border-black  rounded ">
         <li className="border-2 m-2 p-5 w-200  border-black  font-bold rounded">
-          <Link href={`/login_page`}>즐겨찾기</Link>
+          <Link href={`/bookmark_page`}>즐겨찾기</Link>
         </li>
         <li className="border-2 m-2 p-5 w-40  border-black font-bold  rounded">
           <Link href={`/etiquette_page`}>화장실 에티켓</Link>


### PR DESCRIPTION
## 📌 관련 이슈


## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
1. 미로그인 시 로그인 화면으로 이동
2. 로그인 한 유저 정보로 북마크 데이터 조회 작업(이전에는 임시값으로 조회함)
3. 즐겨찾기 메뉴 url 변경
```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
처음에는 zustand에 저장된 유저 정보로 로그인 여부를 체크하려고 했는데, 처음에 빈 값을 가져오고 나서 제대로 값이 가져와지는 문제가 있었습니다. 
근본적인 해결은 하지 못하고 로그인 유무 체크하는 부분을 로컬 스토리지에 있는 값으로 체크하도록 변경하여 해결하였습니다.

zustand에 있는 값을 가져올 때 왜 처음에 빈 값으로 가져와지는지 이유를 찾는 중입니다.

[적용한 방법]
```
useEffect(() => {
    const { user } = JSON.parse(localStorage.getItem('sb-pqqdwvdmqkezxbipblds-auth-token') as string);

    if (!user.id) {
      router.replace('/login_page');
    }
  }, []);
```