### PR TITLE
[단테] : home_page 전반적인 디자인 다시함

### DIFF
--- a/src/app/(Layout)/home_page/page.tsx
+++ b/src/app/(Layout)/home_page/page.tsx
@@ -31,56 +31,43 @@ const HomePage = () => {
         handleSelectCounty={handleSelectCounty}
       />
 
-      <section className="flex md:flex flex-col md:flex-row justify-between">
-        <div className="mt-10 w-2/1">
-          <HomeCategory />
+      <section className="flex md:flex flex-col sm:flex-row justify-between items-center ">
+        <div className="flex justify-start ">
+          <div className="border-2 m-2 p-10 w-auto rounded-md bg-slate-100 ">
+            <HomeCategory />
+          </div>
         </div>
 
         <Map
           id="map"
           center={selectState.center}
           isPanto={selectState.isPanto}
-          className="w-full h-screen   "
+          className="w-10/12 h-96 m-10 rounded"
           level={selectLevel}
         >
           <HomePageMap userLocation={userLocation} nearestLocation={nearestLocation} filterData={filterData} />
         </Map>
       </section>
 
-      <div className="flex overflow-x-auto">
+      <div className="flex flex-col">
         {nearestLocation &&
           nearestLocation.map((location: NearestLocation) => (
-            <figure
-              key={location.toilet_id}
-              className="border-2 m-4 p-4 rounded-2xl  border-blue-50 bg-blue-50  shadow-xl h-30"
-            >
-              <figcaption>
-                <p>
-                  <small className="p-2">
-                    <b>이름:</b> {location.toilet_name}
-                  </small>
+            <div key={location.toilet_id} className="m-4 rounded-xl overflow-hidden shadow-lg bg-white mb-6">
+              <div className="px-6 py-4">
+                <div className="font-bold text-lg mb-2 text-blue-500">{location.toilet_name}</div>
+                <p className="text-gray-700 text-base">
+                  <b>주소:</b> {location.toilet_address}
                 </p>
-                <br />
-                <p>
-                  <small className="p-2 md:p-0 text-sm">
-                    <b>주소:</b>
-                    {location.toilet_address}
-                  </small>
+                <p className="text-gray-700 text-base">
+                  <b>위치:</b> {Math.floor(location.toilet_distance)} km
                 </p>
-                <br />
-                <p className="p-2">
-                  <small>
-                    <b>위치:</b>
-                  </small>
-                  <b>{Math.floor(location.toilet_distance)}</b>
-                  km
-                </p>
-
-                <Link href={`detail_page/${location.toilet_id}`} className="pl-40 p-2 hover:font-bold   md:text-sm ">
+              </div>
+              <div className="px-6 py-4">
+                <Link href={`detail_page/${location.toilet_id}`} className="text-blue-500 hover:font-bold text-sm">
                   more
                 </Link>
-              </figcaption>
-            </figure>
+              </div>
+            </div>
           ))}
       </div>
     </>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,7 +64,7 @@ const Header = () => {
       >
         <BiCurrentLocation size="25" color="black" />
         <div className={`flex flex-col min-w-20 pl-1 text-xs text-left`}>
-          현재 나의 위치{' '}
+          현재 나의 위치
           <span className="text-sm font-semibold">{userAddress ? <p>{userAddress}</p> : <p>찾는중</p>}</span>
         </div>
       </button>

--- a/src/components/home_page/HomeCategory.tsx
+++ b/src/components/home_page/HomeCategory.tsx
@@ -1,20 +1,45 @@
+import { useState } from 'react';
+import { BiCategory } from 'react-icons/bi';
+import { IoIosMan } from 'react-icons/io';
+import { MdFavorite, MdTipsAndUpdates } from 'react-icons/md';
 import Link from 'next/link';
 
 function HomeCategory() {
+  const [isOpen, setIsOpen] = useState(true); // 토글 상태를 관리하기 위한 상태
+
+  const toggleCategory = () => {
+    setIsOpen(!isOpen); // 토글 상태 변경
+  };
+
   return (
-  <nav>
-    <ul className="w-auto m-10">
-      <li className="p-5 border-gray-500 m-3  rounded-md shadow-sm  hover:shadow-md   hover:font-bold hover: hover:shadow-slate-400 ">
-        <Link href={`/bookmark_page`}>Favorite</Link>
-      </li>
-      <li className="p-5 border-gray-500 m-3 rounded-md  shadow-sm hover:shadow-md  hover:font-bold hover:  hover:shadow-slate-400">
-        <Link href={`/etiquette_page`}>Etiquette</Link>
-      </li>
-      <li className="p-5 border-gray-500 m-3  rounded-md  shadow-sm hover:shadow-md   hover:font-bold hover:  hover:shadow-slate-400">
-        <Link href={`/tip_page`}>TIP</Link>
-      </li>
-    </ul>
-  </nav>
+    <nav className="flex justify-left items-start flex-col flex-start md:w-full">
+      <div className="flex items-center cursor-pointer" onClick={toggleCategory}>
+        <BiCategory size={20} className="mr-auto flex justify-start start-0 md:object-no" />
+        <span className="text-gray-800 hover:text-red-500 transition duration-300 p-2">Categories</span>
+      </div>
+      {isOpen && ( // isOpen이 true일 때만 카테고리 목록을 보여줌
+        <ul className="flex flex-col md:flex items-start md:w-full">
+          <li className="hover:border-red-500 rounded-md p-2 flex items-center m-3 border-2 bg-slate-100">
+            <MdFavorite className="text-red-500 mr-2" />
+            <Link href="/bookmark_page" className="text-gray-800 hover:text-red-500 transition duration-300 p-2">
+              Favorite
+            </Link>
+          </li>
+          <li className="hover:border-blue-600 rounded-md p-2 flex items-center m-3 border-2 bg-slate-100">
+            <IoIosMan className="text-blue-600 mr-2" />
+            <Link href="/etiquette_page" className="text-gray-800 hover:text-blue-600 transition duration-300 p-2">
+              Etiquette
+            </Link>
+          </li>
+          <li className="hover:border-yellow-400 rounded-md p-2 flex items-center m-3 border-2 bg-slate-100">
+            <MdTipsAndUpdates className="text-yellow-400 mr-2" />
+            <Link href="/tip_page" className="text-gray-800 hover:text-yellow-400 transition duration-300 p-2">
+              Its TIP
+            </Link>
+          </li>
+        </ul>
+      )}
+    </nav>
   );
 }
 

--- a/src/components/home_page/HomeSelectForm.tsx
+++ b/src/components/home_page/HomeSelectForm.tsx
@@ -3,47 +3,52 @@ import { HomeSelectFormType } from '@/types/home_page/types';
 function HomeSelectForm({ selectSee, selectGunGue, handleSelectCity, handleSelectCounty }: HomeSelectFormType) {
   return (
     <>
-      <form>
-        <select
-          value={selectSee}
-          onChange={handleSelectCity}
-          className="border-2 m-2 p-2 text-black border-black font-bold"
-        >
-          <option value="시 선택">시/도 선택</option>
+      <form className=" m-2 flex justify-center align-center ">
+        <div className="flex items-center  justify-between  ">
+          <p className="p-4 font-bold text-1xl  sm:text-xl ">지역명으로 검색하기</p>
+          <div>
+            <select
+              value={selectSee}
+              onChange={handleSelectCity}
+              className="border-2 m-2 p-2 text-black border-black font-bold "
+            >
+              <option value="시 선택">시/도 선택</option>
 
-          <option value="서울특별시">서울특별시</option>
-          <option value="대구광역시">대구광역시</option>
-          <option value="경기도">경기도</option>
-        </select>
+              <option value="서울특별시">서울특별시</option>
+              <option value="대구광역시">대구광역시</option>
+              <option value="경기도">경기도</option>
+            </select>
 
-        <select
-          value={selectGunGue}
-          onChange={handleSelectCounty}
-          className="border-2 m-2 p-2 text-black border-black font-bold"
-        >
-          <option value="구 선택">군/구 선택</option>
+            <select
+              value={selectGunGue}
+              onChange={handleSelectCounty}
+              className="border-2 m-2 p-2 text-black border-black font-bold"
+            >
+              <option value="구 선택">군/구 선택</option>
 
-          {selectSee === '서울특별시' && (
-            <>
-              <optgroup label="서울특별시">
-                <option value="강동구">강동구</option>
-                <option value="양천구">양천구</option>
-              </optgroup>
-            </>
-          )}
+              {selectSee === '서울특별시' && (
+                <>
+                  <optgroup label="서울특별시">
+                    <option value="강동구">강동구</option>
+                    <option value="양천구">양천구</option>
+                  </optgroup>
+                </>
+              )}
 
-          {selectSee === '대구광역시' && (
-            <optgroup label="대구광역시">
-              <option value="군위군">군위군</option>
-            </optgroup>
-          )}
+              {selectSee === '대구광역시' && (
+                <optgroup label="대구광역시">
+                  <option value="군위군">군위군</option>
+                </optgroup>
+              )}
 
-          {selectSee === '경기도' && (
-            <optgroup label="안양시">
-              <option value="석수동">석수동</option>
-            </optgroup>
-          )}
-        </select>
+              {selectSee === '경기도' && (
+                <optgroup label="안양시">
+                  <option value="석수동">석수동</option>
+                </optgroup>
+              )}
+            </select>
+          </div>
+        </div>
       </form>
     </>
   );


### PR DESCRIPTION
## 계기
- 기존의 디자인은  이것을 디자인한 나에게  평범해 보여서  , 새로운 디자인을 추가하기로 하였다.  
- 기존에 홈페이지들 보면 반응 형이 되면 토클 기능을 해주고 싶었다. 

## Task TODOLIST
- [x]  반응형일때 `토클형 버튼` 만들기 
- [x]  홈페이지 전반적으로 다시 디자인하기 



## 📸 스크린샷

**pc일때** <br>

https://github.com/wheres-my-toilet/wheres-my-toilet/assets/98266983/d8a00aad-b054-406d-9a13-745d81e50447

**모바일일때** <br>

https://github.com/wheres-my-toilet/wheres-my-toilet/assets/98266983/ee98b53f-e47d-41dd-9de5-aeb5485e7be3


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- tailwindcss 는  반응형 홈페이지를 만드는데 기본적인 리소스를 제공합니다.
  
 참고 (https://tailwindcss.com/docs/responsive-design)

```html5
   <!--  md 를 이용하면 반응형 페이지에 맞는 값을  설정해줄수 있다.   -->
  <nav className="flex justify-left items-start flex-col flex-start md:w-full">
```


